### PR TITLE
fix: copy button stays fixed on horizontal scroll

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -296,12 +296,12 @@ table {
   vertical-align: middle;
 }
 
-// Code block container
-pre {
+// Code block wrapper — holds both copy button and pre
+.code-wrapper {
   position: relative;
 }
 
-// Copy button
+// Copy button — positioned relative to wrapper, not pre
 .copy-button {
   position: absolute;
   top: 5px;
@@ -316,6 +316,7 @@ pre {
   cursor: pointer;
   opacity: 0;
   transition: opacity 0.2s;
+  z-index: 1;
 
   &:hover {
     background-color: #e5e5e5;
@@ -327,7 +328,7 @@ pre {
 }
 
 // Show copy button on hover
-pre:hover .copy-button {
+.code-wrapper:hover .copy-button {
   opacity: 1;
 }
 

--- a/_templates/page.html
+++ b/_templates/page.html
@@ -55,25 +55,29 @@
     <script>
     document.addEventListener('DOMContentLoaded', function() {
       // Add copy buttons to all code blocks
+      // Wrap each pre in a .code-wrapper so the button stays fixed
+      // while the code scrolls horizontally
       document.querySelectorAll('pre > code').forEach(function(codeBlock) {
-        // Create button
+        var pre = codeBlock.parentNode;
+
+        // Create wrapper
+        var wrapper = document.createElement('div');
+        wrapper.className = 'code-wrapper';
+        pre.parentNode.insertBefore(wrapper, pre);
+        wrapper.appendChild(pre);
+
+        // Create button inside wrapper (outside pre)
         var button = document.createElement('button');
         button.className = 'copy-button';
         button.textContent = 'Copy';
-        
-        // Add button to pre element (parent of code block)
-        codeBlock.parentNode.appendChild(button);
-        
+        wrapper.appendChild(button);
+
         // Add click handler
         button.addEventListener('click', function() {
-          // Copy code
           var code = codeBlock.textContent;
           navigator.clipboard.writeText(code).then(function() {
-            // Success feedback
             button.textContent = 'Copied!';
             button.classList.add('success');
-            
-            // Reset after 2 seconds
             setTimeout(function() {
               button.textContent = 'Copy';
               button.classList.remove('success');
@@ -81,8 +85,6 @@
           }).catch(function(err) {
             console.error('Failed to copy:', err);
             button.textContent = 'Error';
-            
-            // Reset after 2 seconds
             setTimeout(function() {
               button.textContent = 'Copy';
             }, 2000);


### PR DESCRIPTION
## Summary
- Copy button on code blocks was scrolling away when code overflowed horizontally
- Wrap each `<pre>` in a `.code-wrapper` div
- Position copy button relative to wrapper (not pre), so it stays in the top-right corner regardless of scroll position

## Changes
- `_sass/_base.scss`: `.code-wrapper` replaces `pre { position: relative }`, hover target updated
- `_templates/page.html`: JS creates wrapper div around pre before appending button

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated DOM/CSS change limited to code block copy-button positioning with no data or security implications.
> 
> **Overview**
> Fixes the code-block copy button drifting during horizontal scrolling by wrapping each `pre` in a positioned `.code-wrapper` and attaching the button to that wrapper instead of the scrolling `pre`.
> 
> Updates styles to target `.code-wrapper` for relative positioning/hover behavior and adds `z-index` to keep the button visible above code content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a19057c28198134dcb6fa923a83b4ed4deae15ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->